### PR TITLE
Fix GitHub casing

### DIFF
--- a/docs/nodes/credentials/ActiveCampaign/README.md
+++ b/docs/nodes/credentials/ActiveCampaign/README.md
@@ -1,6 +1,6 @@
 # ActiveCampaign
 
-You can find information about the operations supported by the ActiveCampaign node on the [integrations](https://n8n.io/integrations/n8n-nodes-base.activeCampaign) page. You can also browse the source code of the node on [Github](https://github.com/n8n-io/n8n/tree/master/packages/nodes-base/nodes/ActiveCampaign).
+You can find information about the operations supported by the ActiveCampaign node on the [integrations](https://n8n.io/integrations/n8n-nodes-base.activeCampaign) page. You can also browse the source code of the node on [GitHub](https://github.com/n8n-io/n8n/tree/master/packages/nodes-base/nodes/ActiveCampaign).
 
 ## Pre-requisites
 

--- a/docs/nodes/credentials/Affinity/README.md
+++ b/docs/nodes/credentials/Affinity/README.md
@@ -1,6 +1,6 @@
 # Affinity
 
-You can find information about the operations supported by the Affinity node on the [integrations](https://n8n.io/integrations/n8n-nodes-base.affinity) page. You can also browse the source code of the node on [Github](https://github.com/n8n-io/n8n/tree/master/packages/nodes-base/nodes/Affinity).
+You can find information about the operations supported by the Affinity node on the [integrations](https://n8n.io/integrations/n8n-nodes-base.affinity) page. You can also browse the source code of the node on [GitHub](https://github.com/n8n-io/n8n/tree/master/packages/nodes-base/nodes/Affinity).
 
 ## Pre-requisites
 

--- a/docs/nodes/credentials/AgileCrm/README.md
+++ b/docs/nodes/credentials/AgileCrm/README.md
@@ -1,6 +1,6 @@
 # AgileCRM
 
-You can find information about the operations supported by the AgileCRM node on the [integrations](https://n8n.io/integrations/n8n-nodes-base.agileCrm) page. You can also browse the source code of the node on [Github](https://github.com/n8n-io/n8n/tree/master/packages/nodes-base/nodes/AgileCrm).
+You can find information about the operations supported by the AgileCRM node on the [integrations](https://n8n.io/integrations/n8n-nodes-base.agileCrm) page. You can also browse the source code of the node on [GitHub](https://github.com/n8n-io/n8n/tree/master/packages/nodes-base/nodes/AgileCrm).
 
 ## Pre-requisites
 

--- a/docs/nodes/credentials/Airtable/README.md
+++ b/docs/nodes/credentials/Airtable/README.md
@@ -1,6 +1,6 @@
 # Airtable
 
-You can find information about the operations supported by the AirTable node on the [integrations](https://n8n.io/integrations/n8n-nodes-base.airtable) page. You can also browse the source code of the node on [Github](https://github.com/n8n-io/n8n/tree/master/packages/nodes-base/nodes/Airtable).
+You can find information about the operations supported by the AirTable node on the [integrations](https://n8n.io/integrations/n8n-nodes-base.airtable) page. You can also browse the source code of the node on [GitHub](https://github.com/n8n-io/n8n/tree/master/packages/nodes-base/nodes/Airtable).
 
 ## Pre-requisites
 

--- a/docs/nodes/credentials/Asana/README.md
+++ b/docs/nodes/credentials/Asana/README.md
@@ -1,6 +1,6 @@
 # Asana
 
-You can find information about the operations supported by the Asana node on the [integrations](https://n8n.io/integrations/n8n-nodes-base.asana) page. You can also browse the source code of the node on [Github](https://github.com/n8n-io/n8n/tree/master/packages/nodes-base/nodes/Asana).
+You can find information about the operations supported by the Asana node on the [integrations](https://n8n.io/integrations/n8n-nodes-base.asana) page. You can also browse the source code of the node on [GitHub](https://github.com/n8n-io/n8n/tree/master/packages/nodes-base/nodes/Asana).
 
 The following is a summary based off Asana's own[ documentation](https://developers.asana.com/docs/authentication-basics) regarding authentication.
 

--- a/docs/nodes/credentials/Bannerbear/README.md
+++ b/docs/nodes/credentials/Bannerbear/README.md
@@ -1,6 +1,6 @@
 # Bannerbear
 
-You can find information about the operations supported by the BannerBear node on the [integrations](https://n8n.io/integrations/n8n-nodes-base.bannerbear) page. You can also browse the source code of the node on [Github](https://github.com/n8n-io/n8n/tree/master/packages/nodes-base/nodes/BannerBear).
+You can find information about the operations supported by the BannerBear node on the [integrations](https://n8n.io/integrations/n8n-nodes-base.bannerbear) page. You can also browse the source code of the node on [GitHub](https://github.com/n8n-io/n8n/tree/master/packages/nodes-base/nodes/BannerBear).
 
 ## Pre-requisites
 

--- a/docs/nodes/credentials/Bitbucket/README.md
+++ b/docs/nodes/credentials/Bitbucket/README.md
@@ -1,6 +1,6 @@
 # Bitbucket
 
-You can find information about the operations supported by the Bitbucket node on the [integrations](https://n8n.io/integrations/n8n-nodes-base.bitbucketTrigger) page. You can also browse the source code of the node on [Github](https://github.com/n8n-io/n8n/tree/master/packages/nodes-base/nodes/Bitbucket).
+You can find information about the operations supported by the Bitbucket node on the [integrations](https://n8n.io/integrations/n8n-nodes-base.bitbucketTrigger) page. You can also browse the source code of the node on [GitHub](https://github.com/n8n-io/n8n/tree/master/packages/nodes-base/nodes/Bitbucket).
 
 
 ## Pre-requisites

--- a/docs/nodes/credentials/Bitly/README.md
+++ b/docs/nodes/credentials/Bitly/README.md
@@ -1,6 +1,6 @@
 # Bitly
 
-You can find information about the operations supported by the Bitly node on the [integrations](https://n8n.io/integrations/n8n-nodes-base.bitly) page. You can also browse the source code of the node on [Github](https://github.com/n8n-io/n8n/tree/master/packages/nodes-base/nodes/Bitly).
+You can find information about the operations supported by the Bitly node on the [integrations](https://n8n.io/integrations/n8n-nodes-base.bitly) page. You can also browse the source code of the node on [GitHub](https://github.com/n8n-io/n8n/tree/master/packages/nodes-base/nodes/Bitly).
 
 ## Pre-requisites
 

--- a/docs/nodes/credentials/Calendly/README.md
+++ b/docs/nodes/credentials/Calendly/README.md
@@ -1,6 +1,6 @@
 # Calendly
 
-You can find information about the operations supported by the Calendly node on the [integrations](https://n8n.io/integrations/n8n-nodes-base.calendlyTrigger) page. You can also browse the source code of the node on [Github](https://github.com/n8n-io/n8n/tree/master/packages/nodes-base/nodes/Calendly).
+You can find information about the operations supported by the Calendly node on the [integrations](https://n8n.io/integrations/n8n-nodes-base.calendlyTrigger) page. You can also browse the source code of the node on [GitHub](https://github.com/n8n-io/n8n/tree/master/packages/nodes-base/nodes/Calendly).
 
 ## Pre-requisites
 

--- a/docs/nodes/credentials/Chargebee/README.md
+++ b/docs/nodes/credentials/Chargebee/README.md
@@ -1,6 +1,6 @@
 # Chargebee
 
-You can find information about the operations supported by the Chargebee node on the [integrations](https://n8n.io/integrations/n8n-nodes-base.chargebee) page. You can also browse the source code of the node on [Github](https://github.com/n8n-io/n8n/tree/master/packages/nodes-base/nodes/Chargebee).
+You can find information about the operations supported by the Chargebee node on the [integrations](https://n8n.io/integrations/n8n-nodes-base.chargebee) page. You can also browse the source code of the node on [GitHub](https://github.com/n8n-io/n8n/tree/master/packages/nodes-base/nodes/Chargebee).
 
 ## Pre-requisites
 

--- a/docs/nodes/credentials/Clearbit/README.md
+++ b/docs/nodes/credentials/Clearbit/README.md
@@ -1,6 +1,6 @@
 # Clearbit
 
-You can find information about the operations supported by the Clearbit node on the [integrations](https://n8n.io/integrations/n8n-nodes-base.clearbit) page. You can also browse the source code of the node on [Github](https://github.com/n8n-io/n8n/tree/master/packages/nodes-base/nodes/Clearbit).
+You can find information about the operations supported by the Clearbit node on the [integrations](https://n8n.io/integrations/n8n-nodes-base.clearbit) page. You can also browse the source code of the node on [GitHub](https://github.com/n8n-io/n8n/tree/master/packages/nodes-base/nodes/Clearbit).
 
 ## Pre-requisites
 

--- a/docs/nodes/credentials/Clickup/README.md
+++ b/docs/nodes/credentials/Clickup/README.md
@@ -1,6 +1,6 @@
 # Clickup
 
-You can find information about the operations supported by the Clickup node on the [integrations](https://n8n.io/integrations/n8n-nodes-base.clickup) page. You can also browse the source code of the node on [Github](https://github.com/n8n-io/n8n/tree/master/packages/nodes-base/nodes/Clickup).
+You can find information about the operations supported by the Clickup node on the [integrations](https://n8n.io/integrations/n8n-nodes-base.clickup) page. You can also browse the source code of the node on [GitHub](https://github.com/n8n-io/n8n/tree/master/packages/nodes-base/nodes/Clickup).
 
 ## Pre-requisites
 

--- a/docs/nodes/credentials/Clockify/README.md
+++ b/docs/nodes/credentials/Clockify/README.md
@@ -1,6 +1,6 @@
 # Clockify
 
-You can find information about the operations supported by the Clockify node on the [integrations](https://n8n.io/integrations/n8n-nodes-base.clockifyTrigger) page. You can also browse the source code of the node on [Github](https://github.com/n8n-io/n8n/tree/master/packages/nodes-base/nodes/Clockify).
+You can find information about the operations supported by the Clockify node on the [integrations](https://n8n.io/integrations/n8n-nodes-base.clockifyTrigger) page. You can also browse the source code of the node on [GitHub](https://github.com/n8n-io/n8n/tree/master/packages/nodes-base/nodes/Clockify).
 
 ## Pre-requisites
 

--- a/docs/nodes/credentials/Cockpit/README.md
+++ b/docs/nodes/credentials/Cockpit/README.md
@@ -1,6 +1,6 @@
 # Cockpit
 
-You can find information about the operations supported by the Cockpit node on the [integrations](https://n8n.io/integrations/n8n-nodes-base.cockpit) page. You can also browse the source code of the node on [Github](https://github.com/n8n-io/n8n/tree/master/packages/nodes-base/nodes/Cockpit).
+You can find information about the operations supported by the Cockpit node on the [integrations](https://n8n.io/integrations/n8n-nodes-base.cockpit) page. You can also browse the source code of the node on [GitHub](https://github.com/n8n-io/n8n/tree/master/packages/nodes-base/nodes/Cockpit).
 
 ## Pre-requisites
 

--- a/docs/nodes/credentials/Coda/README.md
+++ b/docs/nodes/credentials/Coda/README.md
@@ -1,6 +1,6 @@
 # Coda
 
-You can find information about the operations supported by the Coda node on the [integrations](https://n8n.io/integrations/n8n-nodes-base.coda) page. You can also browse the source code of the node on [Github](https://github.com/n8n-io/n8n/tree/master/packages/nodes-base/nodes/Coda).
+You can find information about the operations supported by the Coda node on the [integrations](https://n8n.io/integrations/n8n-nodes-base.coda) page. You can also browse the source code of the node on [GitHub](https://github.com/n8n-io/n8n/tree/master/packages/nodes-base/nodes/Coda).
 
 ## Pre-requisites
 

--- a/docs/nodes/credentials/Copper/README.md
+++ b/docs/nodes/credentials/Copper/README.md
@@ -1,6 +1,6 @@
 # Copper
 
-You can find information about the operations supported by the Copper node on the [integrations](https://n8n.io/integrations/n8n-nodes-base.copperTrigger) page. You can also browse the source code of the node on [Github](https://github.com/n8n-io/n8n/tree/master/packages/nodes-base/nodes/Copper).
+You can find information about the operations supported by the Copper node on the [integrations](https://n8n.io/integrations/n8n-nodes-base.copperTrigger) page. You can also browse the source code of the node on [GitHub](https://github.com/n8n-io/n8n/tree/master/packages/nodes-base/nodes/Copper).
 
 ## Pre-requisites
 

--- a/docs/nodes/credentials/Discord/README.md
+++ b/docs/nodes/credentials/Discord/README.md
@@ -1,5 +1,5 @@
 # Discord
-You can find information about the operations supported by the Discord node on the [integrations](https://n8n.io/integrations/n8n-nodes-base.discord) page. You can also browse the source code of the node on [Github](https://github.com/n8n-io/n8n/tree/master/packages/nodes-base/nodes/Discord).
+You can find information about the operations supported by the Discord node on the [integrations](https://n8n.io/integrations/n8n-nodes-base.discord) page. You can also browse the source code of the node on [GitHub](https://github.com/n8n-io/n8n/tree/master/packages/nodes-base/nodes/Discord).
 
 
 ## Pre-requisites

--- a/docs/nodes/credentials/Disqus/README.md
+++ b/docs/nodes/credentials/Disqus/README.md
@@ -1,6 +1,6 @@
 # Disqus
 
-You can find information about the operations supported by the Disqus node on the [integrations](https://n8n.io/integrations/n8n-nodes-base.disqus) page. You can also browse the source code of the node on [Github](https://github.com/n8n-io/n8n/tree/master/packages/nodes-base/nodes/Disqus).
+You can find information about the operations supported by the Disqus node on the [integrations](https://n8n.io/integrations/n8n-nodes-base.disqus) page. You can also browse the source code of the node on [GitHub](https://github.com/n8n-io/n8n/tree/master/packages/nodes-base/nodes/Disqus).
 
 ## Pre-requisites
 

--- a/docs/nodes/credentials/Drift/README.md
+++ b/docs/nodes/credentials/Drift/README.md
@@ -1,6 +1,6 @@
 # Drift
 
-You can find information about the operations supported by the Drift node on the [integrations](https://n8n.io/integrations/n8n-nodes-base.drift) page. You can also browse the source code of the node on [Github](https://github.com/n8n-io/n8n/tree/master/packages/nodes-base/nodes/Drift).
+You can find information about the operations supported by the Drift node on the [integrations](https://n8n.io/integrations/n8n-nodes-base.drift) page. You can also browse the source code of the node on [GitHub](https://github.com/n8n-io/n8n/tree/master/packages/nodes-base/nodes/Drift).
 
 ## Pre-requisites
 

--- a/docs/nodes/credentials/Eventbrite/README.md
+++ b/docs/nodes/credentials/Eventbrite/README.md
@@ -1,6 +1,6 @@
 # Eventbrite
 
-You can find information about the operations supported by the Eventbrite node on the [integrations](https://n8n.io/integrations/n8n-nodes-base.eventbrite) page. You can also browse the source code of the node on [Github](https://github.com/n8n-io/n8n/tree/master/packages/nodes-base/nodes/Eventbrite).
+You can find information about the operations supported by the Eventbrite node on the [integrations](https://n8n.io/integrations/n8n-nodes-base.eventbrite) page. You can also browse the source code of the node on [GitHub](https://github.com/n8n-io/n8n/tree/master/packages/nodes-base/nodes/Eventbrite).
 
 ## Pre-requisites
 

--- a/docs/nodes/credentials/Facebook/README.md
+++ b/docs/nodes/credentials/Facebook/README.md
@@ -1,6 +1,6 @@
 # Facebook
 
-You can find information about the operations supported by the Facebook node on the [integrations](https://n8n.io/integrations/n8n-nodes-base.facebookGraphApi) page. You can also browse the source code of the node on [Github](https://github.com/n8n-io/n8n/tree/master/packages/nodes-base/nodes/Facebook).
+You can find information about the operations supported by the Facebook node on the [integrations](https://n8n.io/integrations/n8n-nodes-base.facebookGraphApi) page. You can also browse the source code of the node on [GitHub](https://github.com/n8n-io/n8n/tree/master/packages/nodes-base/nodes/Facebook).
 
 ## Pre-requisites
 

--- a/docs/nodes/credentials/Flow/README.md
+++ b/docs/nodes/credentials/Flow/README.md
@@ -1,6 +1,6 @@
 # Flow
 
-You can find information about the operations supported by the Flow node on the [integrations](https://n8n.io/integrations/n8n-nodes-base.flow) page. You can also browse the source code of the node on [Github](https://github.com/n8n-io/n8n/tree/master/packages/nodes-base/nodes/Flow).
+You can find information about the operations supported by the Flow node on the [integrations](https://n8n.io/integrations/n8n-nodes-base.flow) page. You can also browse the source code of the node on [GitHub](https://github.com/n8n-io/n8n/tree/master/packages/nodes-base/nodes/Flow).
 
 ## Pre-requisites
 

--- a/docs/nodes/credentials/Freshdesk/README.md
+++ b/docs/nodes/credentials/Freshdesk/README.md
@@ -1,6 +1,6 @@
 # Freshdesk
 
-You can find information about the operations supported by the Freshdesk node on the [integrations](https://n8n.io/integrations/n8n-nodes-base.freshdesk) page. You can also browse the source code of the node on [Github](https://github.com/n8n-io/n8n/tree/master/packages/nodes-base/nodes/Freshdesk).
+You can find information about the operations supported by the Freshdesk node on the [integrations](https://n8n.io/integrations/n8n-nodes-base.freshdesk) page. You can also browse the source code of the node on [GitHub](https://github.com/n8n-io/n8n/tree/master/packages/nodes-base/nodes/Freshdesk).
 
 ## Pre-requisites
 

--- a/docs/nodes/credentials/Github/README.md
+++ b/docs/nodes/credentials/Github/README.md
@@ -1,33 +1,33 @@
-# Github
+# GitHub
 
-You can find information about the operations supported by the Github node on the [integrations](https://n8n.io/integrations/n8n-nodes-base.github) page. You can also browse the source code of the node on [Github](https://github.com/n8n-io/n8n/tree/master/packages/nodes-base/nodes/Github).
+You can find information about the operations supported by the GitHub node on the [integrations](https://n8n.io/integrations/n8n-nodes-base.github) page. You can also browse the source code of the node on [GitHub](https://github.com/n8n-io/n8n/tree/master/packages/nodes-base/nodes/GitHub).
 
 
 ## Pre-requisites
 
-Create a [Github](https://github.com/) account.
+Create a [GitHub](https://github.com/) account.
 
 ## Using OAuth
 
-1. Access your Github dashboard.
+1. Access your GitHub dashboard.
 2. Click on your user icon in the top right.
 3. Click on Settings.
 4. Click on Developer Settings.
 5. Choose OAuth apps.
 6. Register a new application.
-7. Use provided Client Secret and Client ID with your Github node credentials in n8n.
+7. Use provided Client Secret and Client ID with your GitHub node credentials in n8n.
 8. Enter n8n provided redirect URL in configuration. ![Redirect URL Explanation here](../README.md).
 
-![Getting Github credentials](./using-oauth.gif)
+![Getting GitHub credentials](./using-oauth.gif)
 
 
 ## Using Access Token
 
-1. Access your Github dashboard.
+1. Access your GitHub dashboard.
 2. Click on your user icon in the top right.
 3. Click on Settings.
 4. Click on Developer Settings.
 5. Choose personal access token.
 6. Use provided credentials with your Freshdesk node credentials in n8n.
 
-![Getting Github credentials](./using-access-token.gif)
+![Getting GitHub credentials](./using-access-token.gif)

--- a/docs/nodes/credentials/SIGNL4/README.md
+++ b/docs/nodes/credentials/SIGNL4/README.md
@@ -1,6 +1,6 @@
 # SIGNL4
 
-You can find information about the operations supported by the SIGNL4 node on the [integrations](https://n8n.io/integrations/n8n-nodes-base.signl4) page. You can also browse the source code of the node on [Github](https://github.com/n8n-io/n8n/tree/master/packages/nodes-base/nodes/Signl4).
+You can find information about the operations supported by the SIGNL4 node on the [integrations](https://n8n.io/integrations/n8n-nodes-base.signl4) page. You can also browse the source code of the node on [GitHub](https://github.com/n8n-io/n8n/tree/master/packages/nodes-base/nodes/Signl4).
 
 ## Pre-requisites
 


### PR DESCRIPTION
This fixes the casing of `Github` to `GitHub` throughout the docs.

This affects display instances of the word, not functional instances like URLs or permalinks.

The single non-display fix is the new dir name `/docs/nodes/credentials/GitHub`.